### PR TITLE
Define v1 scope and non-goals baseline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,3 +24,5 @@
 - Use focused PRs with clear scope.
 - Include test/validation notes in PR description.
 - For security-sensitive changes, include policy impact notes.
+- For architecture-impacting changes, include an `ADR:` reference in the PR description.
+- If no ADR applies, include `ADR: none (reason)` in the PR description.

--- a/README.md
+++ b/README.md
@@ -29,5 +29,6 @@ This repository currently contains:
 ## Design Docs
 
 - [System Design](docs/coding-agents/aivp-v1-system-design.md)
+- [v1 Scope and Non-Goals](docs/coding-agents/v1-scope-and-non-goals.md)
 - [ADR Index](docs/coding-agents/adrs/README.md)
 - [Implementation Roadmap](docs/coding-agents/implementation-roadmap.md)

--- a/docs/coding-agents/v1-scope-and-non-goals.md
+++ b/docs/coding-agents/v1-scope-and-non-goals.md
@@ -1,7 +1,7 @@
 # aivp v1 Scope and Non-Goals
 
-Status: Approved baseline for v1 delivery  
-Date: 2026-02-26  
+Status: Approved baseline for v1 delivery
+Date: 2026-02-26
 Primary reference: ADR-0001
 
 ## 1. Scope Statement
@@ -48,4 +48,3 @@ Tracking issues:
 - v1 scope doc (in/out): covered by sections 1-3.
 - explicit non-goals list: covered by section 4.
 - deferred features list tracked as post-v1: covered by section 5 and linked issues.
-

--- a/docs/coding-agents/v1-scope-and-non-goals.md
+++ b/docs/coding-agents/v1-scope-and-non-goals.md
@@ -1,0 +1,51 @@
+# aivp v1 Scope and Non-Goals
+
+Status: Approved baseline for v1 delivery  
+Date: 2026-02-26  
+Primary reference: ADR-0001
+
+## 1. Scope Statement
+
+aivp v1 is a local-first, single-user framework for defining and running narrowly scoped AI agents ("AI VPs") with least-privilege, policy-enforced execution boundaries.
+
+## 2. In Scope (v1)
+
+- Local daemon runtime on user laptops, with macOS-first focus and Linux close second.
+- YAML-first agent configuration with schema versioning and migration path.
+- Capability-secure skill execution through a central non-agentic executor.
+- Policy enforcement with deny-wins precedence and risk-based approval controls.
+- Scheduling + event-trigger workflows with bounded catch-up and replay support.
+- Structured local observability (runs, steps, skill calls, errors) and audit export.
+- Budget/quota controls and policy-based model routing.
+- CLI-first developer/operator workflow.
+
+## 3. Out of Scope (v1)
+
+- Multi-user collaborative operation.
+- Cloud-hosted control plane as a core deployment target.
+- Broad personal-assistant behavior with open-ended permissions.
+- Mandatory enterprise controls (for example: mandatory DB encryption, mandatory OTel).
+- Full marketplace automation and auto-update by default.
+
+## 4. Explicit Non-Goals
+
+- Not a general-purpose autonomous assistant with unrestricted tool access.
+- Not a replacement for enterprise orchestration platforms.
+- Not a guarantee of exactly-once effects across external provider APIs.
+- Not a framework that trusts prompt instructions as the sole permission boundary.
+
+## 5. Deferred Post-v1 Features (Tracked)
+
+- Multi-profile isolation on one machine (post-v1 target, see ADR-0011 / D054).
+- macOS app bundle and launch-agent packaging (post-v1 target, see ADR-0011 / D055).
+
+Tracking issues:
+- #22 post-v1: multi-profile isolation
+- #23 post-v1: macOS app bundle packaging
+
+## 6. Acceptance Criteria Mapping for Issue #1
+
+- v1 scope doc (in/out): covered by sections 1-3.
+- explicit non-goals list: covered by section 4.
+- deferred features list tracked as post-v1: covered by section 5 and linked issues.
+


### PR DESCRIPTION
## Summary
- add v1 scope and non-goals document with explicit in-scope/out-of-scope boundaries
- include explicit deferred post-v1 feature list and tracking links
- update README design docs list and CONTRIBUTING PR guardrails
- create deferred tracking issues: #22 and #23

## Validation
- PYTHONPATH=src python3 -m unittest discover -s tests -v

Closes #1