### PR TITLE
Implement daemon bootstrap lifecycle with PID locking

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,55 @@
+name: PR CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: Lint (pre-commit)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install pre-commit
+        run: python -m pip install --upgrade pip pre-commit
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+
+  test:
+    name: Unit tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.11"
+          - "3.12"
+          - "3.13"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+
+      - name: Run tests
+        run: python -m unittest discover -s tests -v
+

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -52,4 +52,3 @@ jobs:
 
       - name: Run tests
         run: python -m unittest discover -s tests -v
-

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ This repository currently contains:
 3. Run scaffold health check:
    - `aivp doctor`
 
+## Daemon Commands
+
+- Start daemon loop (foreground):
+  - `aivp daemon start --pid-file runtime/daemon.pid`
+- Stop daemon:
+  - `aivp daemon stop --pid-file runtime/daemon.pid`
+- Restart daemon:
+  - `aivp daemon restart --pid-file runtime/daemon.pid`
+
 ## Repository Layout
 
 - `src/aivp/` Python package scaffold

--- a/README.md
+++ b/README.md
@@ -20,11 +20,16 @@ This repository currently contains:
 ## Daemon Commands
 
 - Start daemon loop (foreground):
-  - `aivp daemon start --pid-file runtime/daemon.pid`
+  - `aivp daemon start --pid-file runtime/daemon.pid [--heartbeat-seconds N] [--max-heartbeats M]`
 - Stop daemon:
   - `aivp daemon stop --pid-file runtime/daemon.pid`
 - Restart daemon:
-  - `aivp daemon restart --pid-file runtime/daemon.pid`
+  - `aivp daemon restart --pid-file runtime/daemon.pid [--heartbeat-seconds N] [--max-heartbeats M]`
+
+Notes:
+- `daemon stop` is idempotent and returns success when the daemon is already stopped.
+- `daemon start` returns a non-zero exit code when a daemon is already running for the same PID file.
+- Use `aivp daemon --help` and subcommand `--help` for additional options.
 
 ## Repository Layout
 

--- a/src/aivp/cli.py
+++ b/src/aivp/cli.py
@@ -66,7 +66,9 @@ def build_parser() -> argparse.ArgumentParser:
     daemon = subparsers.add_parser("daemon", help="Daemon lifecycle controls.")
     daemon_subparsers = daemon.add_subparsers(dest="daemon_command", required=True)
 
-    daemon_start = daemon_subparsers.add_parser("start", help="Start foreground daemon.")
+    daemon_start = daemon_subparsers.add_parser(
+        "start", help="Start foreground daemon."
+    )
     daemon_start.add_argument("--pid-file", default="runtime/daemon.pid")
     daemon_start.add_argument("--heartbeat-seconds", type=float, default=30.0)
     daemon_start.add_argument("--max-heartbeats", type=int)

--- a/src/aivp/cli.py
+++ b/src/aivp/cli.py
@@ -34,7 +34,7 @@ def _cmd_daemon_start(args: argparse.Namespace) -> int:
 def _cmd_daemon_stop(args: argparse.Namespace) -> int:
     result = DaemonRunner(Path(args.pid_file).resolve()).stop()
     print(json.dumps(asdict(result), indent=2))
-    return 0
+    return 0 if result.status in {"stopped", "not_running"} else 1
 
 
 def _cmd_daemon_restart(args: argparse.Namespace) -> int:
@@ -71,7 +71,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     daemon_start.add_argument("--pid-file", default="runtime/daemon.pid")
     daemon_start.add_argument("--heartbeat-seconds", type=float, default=30.0)
-    daemon_start.add_argument("--max-heartbeats", type=int)
+    daemon_start.add_argument(
+        "--max-heartbeats",
+        type=int,
+        help="Maximum number of heartbeat sleep cycles before exiting.",
+    )
     daemon_start.set_defaults(func=_cmd_daemon_start)
 
     daemon_stop = daemon_subparsers.add_parser("stop", help="Stop daemon by pid file.")
@@ -83,7 +87,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     daemon_restart.add_argument("--pid-file", default="runtime/daemon.pid")
     daemon_restart.add_argument("--heartbeat-seconds", type=float, default=30.0)
-    daemon_restart.add_argument("--max-heartbeats", type=int)
+    daemon_restart.add_argument(
+        "--max-heartbeats",
+        type=int,
+        help="Maximum number of heartbeat sleep cycles before exiting.",
+    )
     daemon_restart.set_defaults(func=_cmd_daemon_restart)
 
     return parser

--- a/src/aivp/cli.py
+++ b/src/aivp/cli.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import argparse
 import json
+from dataclasses import asdict
 from pathlib import Path
 
+from aivp.runtime.daemon import DaemonRunner
 from aivp.server.app import ServerConfig, build_server_summary
 
 
@@ -17,6 +19,30 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
         backups_dir=Path(args.backups_dir).resolve(),
     )
     print(json.dumps(build_server_summary(config), indent=2))
+    return 0
+
+
+def _cmd_daemon_start(args: argparse.Namespace) -> int:
+    result = DaemonRunner(Path(args.pid_file).resolve()).start(
+        heartbeat_seconds=args.heartbeat_seconds,
+        max_heartbeats=args.max_heartbeats,
+    )
+    print(json.dumps(asdict(result), indent=2))
+    return 0 if result.status in {"started", "restart_complete"} else 1
+
+
+def _cmd_daemon_stop(args: argparse.Namespace) -> int:
+    result = DaemonRunner(Path(args.pid_file).resolve()).stop()
+    print(json.dumps(asdict(result), indent=2))
+    return 0
+
+
+def _cmd_daemon_restart(args: argparse.Namespace) -> int:
+    result = DaemonRunner(Path(args.pid_file).resolve()).restart(
+        heartbeat_seconds=args.heartbeat_seconds,
+        max_heartbeats=args.max_heartbeats,
+    )
+    print(json.dumps(asdict(result), indent=2))
     return 0
 
 
@@ -36,6 +62,27 @@ def build_parser() -> argparse.ArgumentParser:
     doctor.add_argument("--artifacts-dir", default="runtime/artifacts")
     doctor.add_argument("--backups-dir", default="runtime/backups")
     doctor.set_defaults(func=_cmd_doctor)
+
+    daemon = subparsers.add_parser("daemon", help="Daemon lifecycle controls.")
+    daemon_subparsers = daemon.add_subparsers(dest="daemon_command", required=True)
+
+    daemon_start = daemon_subparsers.add_parser("start", help="Start foreground daemon.")
+    daemon_start.add_argument("--pid-file", default="runtime/daemon.pid")
+    daemon_start.add_argument("--heartbeat-seconds", type=float, default=30.0)
+    daemon_start.add_argument("--max-heartbeats", type=int)
+    daemon_start.set_defaults(func=_cmd_daemon_start)
+
+    daemon_stop = daemon_subparsers.add_parser("stop", help="Stop daemon by pid file.")
+    daemon_stop.add_argument("--pid-file", default="runtime/daemon.pid")
+    daemon_stop.set_defaults(func=_cmd_daemon_stop)
+
+    daemon_restart = daemon_subparsers.add_parser(
+        "restart", help="Restart daemon using pid file."
+    )
+    daemon_restart.add_argument("--pid-file", default="runtime/daemon.pid")
+    daemon_restart.add_argument("--heartbeat-seconds", type=float, default=30.0)
+    daemon_restart.add_argument("--max-heartbeats", type=int)
+    daemon_restart.set_defaults(func=_cmd_daemon_restart)
 
     return parser
 

--- a/src/aivp/runtime/__init__.py
+++ b/src/aivp/runtime/__init__.py
@@ -1,0 +1,2 @@
+"""Runtime package for aivp."""
+

--- a/src/aivp/runtime/__init__.py
+++ b/src/aivp/runtime/__init__.py
@@ -1,2 +1,1 @@
 """Runtime package for aivp."""
-

--- a/src/aivp/runtime/daemon.py
+++ b/src/aivp/runtime/daemon.py
@@ -1,0 +1,167 @@
+"""Daemon lifecycle and PID lock utilities."""
+
+from __future__ import annotations
+
+import os
+import signal
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+class PidLockError(RuntimeError):
+    """Raised when a daemon lock cannot be acquired."""
+
+
+def pid_is_running(pid: int) -> bool:
+    """Return True when the process exists or is inaccessible by permissions."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _read_pid(pid_file: Path) -> int | None:
+    if not pid_file.exists():
+        return None
+    raw = pid_file.read_text(encoding="utf-8").strip()
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+@dataclass
+class PidFileLock:
+    """Exclusive lock represented by a PID file."""
+
+    pid_file: Path
+    held: bool = False
+
+    def acquire(self) -> None:
+        self.pid_file.parent.mkdir(parents=True, exist_ok=True)
+        existing_pid = _read_pid(self.pid_file)
+
+        if existing_pid is not None:
+            if pid_is_running(existing_pid):
+                raise PidLockError(
+                    f"Daemon appears to be running with pid={existing_pid}"
+                )
+            # stale lock: remove and continue
+            self.pid_file.unlink(missing_ok=True)
+
+        self.pid_file.write_text(str(os.getpid()), encoding="utf-8")
+        self.held = True
+
+    def release(self) -> None:
+        if not self.held:
+            return
+        current_pid = _read_pid(self.pid_file)
+        if current_pid == os.getpid():
+            self.pid_file.unlink(missing_ok=True)
+        self.held = False
+
+
+@dataclass(frozen=True)
+class DaemonActionResult:
+    status: Literal[
+        "started",
+        "already_running",
+        "stopped",
+        "not_running",
+        "restart_complete",
+    ]
+    message: str
+    pid: int | None = None
+
+
+class DaemonRunner:
+    """Foreground daemon runner that holds the PID lock for its lifetime."""
+
+    def __init__(self, pid_file: Path) -> None:
+        self.pid_file = pid_file
+        self._running = True
+
+    def _handle_signal(self, _signum: int, _frame: object) -> None:
+        self._running = False
+
+    def start(
+        self,
+        heartbeat_seconds: float = 30.0,
+        max_heartbeats: int | None = None,
+    ) -> DaemonActionResult:
+        lock = PidFileLock(self.pid_file)
+        try:
+            lock.acquire()
+        except PidLockError:
+            existing_pid = _read_pid(self.pid_file)
+            return DaemonActionResult(
+                status="already_running",
+                message="daemon start blocked by active pid lock",
+                pid=existing_pid,
+            )
+
+        old_sigterm = signal.signal(signal.SIGTERM, self._handle_signal)
+        old_sigint = signal.signal(signal.SIGINT, self._handle_signal)
+        try:
+            beats = 0
+            while self._running:
+                if max_heartbeats is not None and beats >= max_heartbeats:
+                    break
+                time.sleep(max(heartbeat_seconds, 0.01))
+                beats += 1
+        finally:
+            signal.signal(signal.SIGTERM, old_sigterm)
+            signal.signal(signal.SIGINT, old_sigint)
+            lock.release()
+
+        return DaemonActionResult(
+            status="started",
+            message="daemon run completed",
+            pid=os.getpid(),
+        )
+
+    def stop(self) -> DaemonActionResult:
+        pid = _read_pid(self.pid_file)
+        if pid is None:
+            return DaemonActionResult(
+                status="not_running",
+                message="no pid lock present",
+            )
+
+        if not pid_is_running(pid):
+            self.pid_file.unlink(missing_ok=True)
+            return DaemonActionResult(
+                status="stopped",
+                message="removed stale pid lock",
+                pid=pid,
+            )
+
+        os.kill(pid, signal.SIGTERM)
+        return DaemonActionResult(
+            status="stopped",
+            message="sent SIGTERM to daemon process",
+            pid=pid,
+        )
+
+    def restart(
+        self,
+        heartbeat_seconds: float = 30.0,
+        max_heartbeats: int | None = None,
+    ) -> DaemonActionResult:
+        self.stop()
+        start_result = self.start(
+            heartbeat_seconds=heartbeat_seconds,
+            max_heartbeats=max_heartbeats,
+        )
+        return DaemonActionResult(
+            status="restart_complete",
+            message="daemon restart sequence completed",
+            pid=start_result.pid,
+        )

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 import os
+import signal
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from aivp.runtime.daemon import DaemonRunner, PidFileLock, PidLockError
+from aivp.runtime.daemon import (
+    DaemonActionResult,
+    DaemonRunner,
+    PidFileLock,
+    PidLockError,
+)
 
 
 class PidFileLockTests(unittest.TestCase):
@@ -65,12 +71,92 @@ class DaemonRunnerTests(unittest.TestCase):
             pid_file = Path(tmpdir) / "daemon.pid"
             pid_file.write_text("1234", encoding="utf-8")
 
-            with patch("aivp.runtime.daemon.pid_is_running", return_value=True):
+            with patch(
+                "aivp.runtime.daemon.pid_is_running",
+                side_effect=[True, False, False],
+            ):
                 with patch("aivp.runtime.daemon.os.kill") as kill_mock:
                     result = DaemonRunner(pid_file).stop()
 
             self.assertEqual(result.status, "stopped")
-            kill_mock.assert_called_once()
+            kill_mock.assert_called_once_with(1234, signal.SIGTERM)
+
+    def test_stop_handles_process_lookup_race(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pid_file = Path(tmpdir) / "daemon.pid"
+            pid_file.write_text("1234", encoding="utf-8")
+
+            with patch("aivp.runtime.daemon.pid_is_running", return_value=True):
+                with patch(
+                    "aivp.runtime.daemon.os.kill", side_effect=ProcessLookupError
+                ):
+                    result = DaemonRunner(pid_file).stop()
+
+            self.assertEqual(result.status, "stopped")
+            self.assertFalse(pid_file.exists())
+
+    def test_start_runner_can_be_reused(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pid_file = Path(tmpdir) / "daemon.pid"
+            runner = DaemonRunner(pid_file)
+
+            first = runner.start(max_heartbeats=0)
+            second = runner.start(max_heartbeats=0)
+
+            self.assertEqual(first.status, "started")
+            self.assertEqual(second.status, "started")
+
+    def test_restart_passes_parameters_to_start(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = DaemonRunner(Path(tmpdir) / "daemon.pid")
+
+            with patch.object(
+                runner,
+                "stop",
+                return_value=DaemonActionResult(
+                    status="stopped",
+                    message="stopped",
+                    pid=111,
+                ),
+            ):
+                with patch.object(
+                    runner,
+                    "start",
+                    return_value=DaemonActionResult(
+                        status="started",
+                        message="started",
+                        pid=222,
+                    ),
+                ) as start_mock:
+                    result = runner.restart(
+                        heartbeat_seconds=0.25,
+                        max_heartbeats=5,
+                    )
+
+            self.assertEqual(result.status, "restart_complete")
+            start_mock.assert_called_once_with(
+                heartbeat_seconds=0.25,
+                max_heartbeats=5,
+            )
+
+    def test_restart_aborts_when_stop_does_not_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = DaemonRunner(Path(tmpdir) / "daemon.pid")
+
+            with patch.object(
+                runner,
+                "stop",
+                return_value=DaemonActionResult(
+                    status="stop_requested",
+                    message="still running",
+                    pid=333,
+                ),
+            ):
+                with patch.object(runner, "start") as start_mock:
+                    result = runner.restart()
+
+            self.assertEqual(result.status, "already_running")
+            start_mock.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -31,7 +31,9 @@ class PidFileLockTests(unittest.TestCase):
                 lock = PidFileLock(pid_file)
                 lock.acquire()
                 try:
-                    self.assertEqual(pid_file.read_text(encoding="utf-8"), str(os.getpid()))
+                    self.assertEqual(
+                        pid_file.read_text(encoding="utf-8"), str(os.getpid())
+                    )
                 finally:
                     lock.release()
 
@@ -42,7 +44,9 @@ class DaemonRunnerTests(unittest.TestCase):
             pid_file = Path(tmpdir) / "daemon.pid"
             pid_file.write_text(str(os.getpid()), encoding="utf-8")
 
-            result = DaemonRunner(pid_file).start(max_heartbeats=1, heartbeat_seconds=0.01)
+            result = DaemonRunner(pid_file).start(
+                max_heartbeats=1, heartbeat_seconds=0.01
+            )
             self.assertEqual(result.status, "already_running")
 
     def test_stop_removes_stale_pid_file(self) -> None:
@@ -71,4 +75,3 @@ class DaemonRunnerTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from aivp.runtime.daemon import DaemonRunner, PidFileLock, PidLockError
+
+
+class PidFileLockTests(unittest.TestCase):
+    def test_second_instance_is_blocked(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pid_file = Path(tmpdir) / "daemon.pid"
+            lock1 = PidFileLock(pid_file)
+            lock1.acquire()
+
+            lock2 = PidFileLock(pid_file)
+            with self.assertRaises(PidLockError):
+                lock2.acquire()
+
+            lock1.release()
+
+    def test_stale_lock_is_recovered(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pid_file = Path(tmpdir) / "daemon.pid"
+            pid_file.write_text("999999", encoding="utf-8")
+
+            with patch("aivp.runtime.daemon.pid_is_running", return_value=False):
+                lock = PidFileLock(pid_file)
+                lock.acquire()
+                try:
+                    self.assertEqual(pid_file.read_text(encoding="utf-8"), str(os.getpid()))
+                finally:
+                    lock.release()
+
+
+class DaemonRunnerTests(unittest.TestCase):
+    def test_start_returns_already_running_when_pid_is_active(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pid_file = Path(tmpdir) / "daemon.pid"
+            pid_file.write_text(str(os.getpid()), encoding="utf-8")
+
+            result = DaemonRunner(pid_file).start(max_heartbeats=1, heartbeat_seconds=0.01)
+            self.assertEqual(result.status, "already_running")
+
+    def test_stop_removes_stale_pid_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pid_file = Path(tmpdir) / "daemon.pid"
+            pid_file.write_text("999999", encoding="utf-8")
+
+            with patch("aivp.runtime.daemon.pid_is_running", return_value=False):
+                result = DaemonRunner(pid_file).stop()
+
+            self.assertEqual(result.status, "stopped")
+            self.assertFalse(pid_file.exists())
+
+    def test_stop_sends_sigterm_for_running_pid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pid_file = Path(tmpdir) / "daemon.pid"
+            pid_file.write_text("1234", encoding="utf-8")
+
+            with patch("aivp.runtime.daemon.pid_is_running", return_value=True):
+                with patch("aivp.runtime.daemon.os.kill") as kill_mock:
+                    result = DaemonRunner(pid_file).stop()
+
+            self.assertEqual(result.status, "stopped")
+            kill_mock.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add runtime daemon module with PID file locking and stale lock recovery
- add foreground daemon lifecycle hooks: start, stop, restart
- wire daemon lifecycle commands into CLI (aivp daemon start|stop|restart)
- add tests covering second-instance blocking, stale lock recovery, and stop behavior
- update README with daemon command usage

## Validation
- PYTHONPATH=src python3 -m unittest discover -s tests -v
- PYTHONPATH=src python3 -m aivp.cli daemon start --pid-file /tmp/aivp-daemon-test.pid --max-heartbeats 1 --heartbeat-seconds 0.01
- PYTHONPATH=src python3 -m aivp.cli daemon restart --pid-file /tmp/aivp-daemon-test.pid --max-heartbeats 1 --heartbeat-seconds 0.01

Closes #2