### PR TITLE
Add SQLite WAL bootstrap and migration state table

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Notes:
 - `daemon start` returns a non-zero exit code when a daemon is already running for the same PID file.
 - Use `aivp daemon --help` and subcommand `--help` for additional options.
 
+## Database Commands
+
+- Initialize runtime SQLite DB (WAL + schema state table):
+  - `aivp db init --db-path runtime/db/aivp.sqlite3 --migration-version v1alpha1`
+
 ## Repository Layout
 
 - `src/aivp/` Python package scaffold

--- a/src/aivp/runtime/db.py
+++ b/src/aivp/runtime/db.py
@@ -1,0 +1,116 @@
+"""SQLite bootstrap and migration-version helpers."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class DbBootstrapResult:
+    db_path: str
+    migration_version: str
+    journal_mode: str
+    wal_enabled: bool
+    created_state_row: bool
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    return sqlite3.connect(db_path)
+
+
+def _normalize_journal_mode(mode: str) -> str:
+    return mode.strip().lower()
+
+
+def bootstrap_sqlite(
+    db_path: Path,
+    initial_migration_version: str = "v1alpha1",
+) -> DbBootstrapResult:
+    """Initialize SQLite runtime DB, WAL mode, and migration state table."""
+    with _connect(db_path) as conn:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS schema_state (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                migration_version TEXT NOT NULL,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+        row = conn.execute(
+            "SELECT migration_version FROM schema_state WHERE id = 1"
+        ).fetchone()
+        created_state_row = False
+
+        if row is None:
+            conn.execute(
+                """
+                INSERT INTO schema_state (id, migration_version)
+                VALUES (1, ?)
+                """,
+                (initial_migration_version,),
+            )
+            migration_version = initial_migration_version
+            created_state_row = True
+        else:
+            migration_version = str(row[0])
+
+        journal_mode_row = conn.execute("PRAGMA journal_mode").fetchone()
+        journal_mode = (
+            _normalize_journal_mode(str(journal_mode_row[0]))
+            if journal_mode_row
+            else "unknown"
+        )
+
+        conn.commit()
+
+    return DbBootstrapResult(
+        db_path=str(db_path),
+        migration_version=migration_version,
+        journal_mode=journal_mode,
+        wal_enabled=journal_mode == "wal",
+        created_state_row=created_state_row,
+    )
+
+
+def get_migration_version(db_path: Path) -> str | None:
+    with _connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT migration_version FROM schema_state WHERE id = 1"
+        ).fetchone()
+        if row is None:
+            return None
+        return str(row[0])
+
+
+def set_migration_version(db_path: Path, migration_version: str) -> None:
+    with _connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS schema_state (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                migration_version TEXT NOT NULL,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO schema_state (id, migration_version)
+            VALUES (1, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                migration_version = excluded.migration_version,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (migration_version,),
+        )
+        conn.commit()
+

--- a/src/aivp/runtime/db.py
+++ b/src/aivp/runtime/db.py
@@ -64,9 +64,7 @@ def bootstrap_sqlite(
         row = conn.execute(
             "SELECT migration_version FROM schema_state WHERE id = 1"
         ).fetchone()
-        migration_version = (
-            initial_migration_version if row is None else str(row[0])
-        )
+        migration_version = initial_migration_version if row is None else str(row[0])
 
         journal_mode_row = conn.execute("PRAGMA journal_mode").fetchone()
         journal_mode = (

--- a/src/aivp/runtime/db.py
+++ b/src/aivp/runtime/db.py
@@ -113,4 +113,3 @@ def set_migration_version(db_path: Path, migration_version: str) -> None:
             (migration_version,),
         )
         conn.commit()
-

--- a/tests/test_runtime_db.py
+++ b/tests/test_runtime_db.py
@@ -43,4 +43,3 @@ class RuntimeDbBootstrapTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Summary
- add runtime DB bootstrap module for SQLite initialization
- initialize SQLite pragmas including journal_mode=WAL
- add migration tracking singleton table (schema_state) with persisted migration version
- add helper functions to read/update migration version
- add CLI command aivp db init for bootstrap flows
- add tests covering idempotent bootstrap and migration persistence across restarts

## Validation
- PYTHONPATH=src python3 -m unittest discover -s tests -v
- PYTHONPATH=src python3 -m aivp.cli db init --db-path /tmp/aivp-db-test.sqlite3 --migration-version v1alpha1
- PYTHONPATH=src python3 -m aivp.cli db init --db-path /tmp/aivp-db-test.sqlite3 --migration-version ignored

Closes #3