### PR TITLE
Design: adopt SKILL.md standard and skill-pool/binding separation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ runtime/artifacts/*
 runtime/backups/*
 !runtime/artifacts/.gitkeep
 !runtime/backups/.gitkeep
+
+.DS_Store

--- a/docs/coding-agents/adrs/ADR-0004-yaml-configuration-contracts-and-activation-lifecycle.md
+++ b/docs/coding-agents/adrs/ADR-0004-yaml-configuration-contracts-and-activation-lifecycle.md
@@ -21,7 +21,7 @@ The product is YAML-first for users, but must stay safe and evolvable over time.
 - Capture immutable per-run snapshots of config, prompt, skill, and policy hashes.
 - Apply draft -> validate -> activate workflow with rollback on invalid changes.
 - Block activation when contract changes break compatibility or widen permissions unexpectedly.
-- Define skill contracts using typed Python models with JSON Schema export.
+- Define skill contracts via `SKILL.md` frontmatter imported into the skill pool (see ADR-0013), while allowing Python SDK types to emit equivalent JSON Schema.
 
 ## Consequences
 

--- a/docs/coding-agents/adrs/ADR-0013-skillmd-standard-skill-pool-and-agent-bindings.md
+++ b/docs/coding-agents/adrs/ADR-0013-skillmd-standard-skill-pool-and-agent-bindings.md
@@ -1,0 +1,36 @@
+# ADR-0013: SKILL.md Standard, Skill Pool, and Agent Binding Separation
+
+- Status: Accepted
+- Date: 2026-03-03
+- Decision IDs: D096, D097, D098, D099, D100
+
+## Context
+
+aivp needs first-class interoperability with the open `SKILL.md` format so users can import reusable skills instead of rewriting tool interfaces per agent. At the same time, agent YAML should remain focused on goals and safety constraints, not redefining skill contracts.
+
+## Decision
+
+- Adopt `SKILL.md` as a first-class skill definition and import standard.
+- Require machine-readable frontmatter in `SKILL.md` for enforceable contract fields (skill id, version, inputs, outputs, permission scope, risk metadata, execution hints).
+- Treat the Markdown body in `SKILL.md` as agent guidance/context, not as the sole enforcement source.
+- Maintain a global skill pool registry populated from imported `SKILL.md` skills.
+- Separate agent-level config from skill definition:
+  - skill pool contains canonical skill contracts,
+  - agent YAML contains only `skill_bindings` (alias + optional argument constraints/overrides).
+- Keep agent binding `fixed` argument maps optional by default, allowing users to tighten some/all arguments for safer mini-agents when desired.
+- Support importing skills from local paths and Git sources with provenance metadata and hash pinning.
+- Block activation when an agent binding references a missing/incompatible skill from the pool.
+- Include resolved skill id/version/hash in immutable run snapshots.
+
+## Consequences
+
+- Skill authoring and sharing become portable and interoperable.
+- Agent YAML is smaller and less repetitive.
+- Safety enforcement stays server-side through skill contracts, policy checks, and executor validation.
+- Imported skill updates become auditable through provenance and hash pinning.
+
+## Alternatives Considered
+
+- Continue using only Python-native skill contracts with no `SKILL.md` import path.
+- Allow agents to redefine skill argument contracts inline in each agent YAML.
+- Treat `SKILL.md` as documentation-only with no machine validation.

--- a/docs/coding-agents/adrs/README.md
+++ b/docs/coding-agents/adrs/README.md
@@ -18,3 +18,4 @@ This folder contains accepted Architecture Decision Records derived from:
 - [ADR-0010 User Interfaces, Local API, and Operational Controls](./ADR-0010-user-interfaces-local-api-and-operational-controls.md)
 - [ADR-0011 Packaging, Platform Support, and Extensibility](./ADR-0011-packaging-platform-support-and-extensibility.md)
 - [ADR-0012 Testing, Determinism, and Skill Developer Experience](./ADR-0012-testing-determinism-and-skill-developer-experience.md)
+- [ADR-0013 SKILL.md Standard, Skill Pool, and Agent Binding Separation](./ADR-0013-skillmd-standard-skill-pool-and-agent-bindings.md)

--- a/docs/coding-agents/aivp-v1-system-design.md
+++ b/docs/coding-agents/aivp-v1-system-design.md
@@ -44,7 +44,7 @@ flowchart LR
 
 - Permission baseline: enforced capability tokens/checks in runtime, not prompt-only controls.
 - Enforcement location: central policy layer + central skill executor.
-- Skill usage pattern: agents request allowed registered skills with constrained parameters; server executes non-agentically using stored secrets.
+- Skill usage pattern: agents request allowed skills from a global skill pool; server executes non-agentically using stored secrets.
 - Policy precedence: explicit `deny` always wins; then nearest-scope `allow`.
 - Approval model: policy DSL by action/resource/risk with per-agent "no-ask" override support.
 - Risk flow: policy-triggered plan/preview before high-risk actions.
@@ -63,7 +63,10 @@ flowchart LR
 - Conflict handling: file-backed source of truth with revision checks + write locks.
 - Prompt governance: versioned prompt artifacts pinned per run.
 - Structured outputs: schema validation + retry/repair loop.
-- Skill contracts: Python-first typed models (Pydantic) with exported JSON Schema.
+- Skill definition standard: `SKILL.md` with required machine-readable frontmatter for enforceable contracts.
+- Skill contract source of truth: imported skill pool registry, separate from per-agent bindings.
+- Agent skill bindings: alias + optional argument constraints/overrides (`fixed`) without redefining full skill interfaces.
+- Skill contracts remain Python-extensible and exportable to JSON Schema for runtime validation.
 - Parameter constraints: declarative schema constraints enforced pre-exec (enum/range/pattern/date windows).
 - Compatibility checks: block activation when contract changes broaden/break permissions unexpectedly.
 
@@ -128,6 +131,7 @@ flowchart LR
 - First-run UX: guided setup wizard + starter templates.
 - Starter templates: curated, versioned local templates with required provenance metadata.
 - Template/skill provenance manifest: source, version/hash, license, permission scope.
+- Imported `SKILL.md` assets: local and Git import flows with validation feedback and lock metadata.
 
 ## 12. Packaging, Platform, and Extensibility
 
@@ -140,6 +144,7 @@ flowchart LR
 - Plugin strategy: versioned extension API with capability flags.
 - Release channels: stable + opt-in beta.
 - Update channel for integrations/skills: signed update feed with explicit user approval.
+- Skill import standard: full `SKILL.md` support for portable third-party skill packs.
 
 ## 13. Testing and Operability
 
@@ -162,6 +167,8 @@ config/
   migrations/
 skills/
   builtin/
+  imported/
+  lockfiles/
 agents/
   templates/
 runtime/
@@ -291,7 +298,7 @@ runtime/
 - D084 `B` signed tamper-evident audit bundles + plain exports.
 - D085 `B` curated versioned local starter templates.
 
-### 86-95 Additional Locked Decisions
+### 86-100 Additional Locked Decisions
 
 - D086 `B` support last 2-3 Python versions.
 - D087 `B` lock dependencies for runtime/core/templates.
@@ -303,6 +310,11 @@ runtime/
 - D093 `B` artifact retention tiers + dedupe/compression + GC.
 - D094 `B` stable + opt-in beta channels.
 - D095 `B` required provenance manifest for skills/templates.
+- D096 `B` full `SKILL.md` support with required contract frontmatter.
+- D097 `B` global skill pool separated from per-agent `skill_bindings`.
+- D098 `B` agent bindings may optionally fix any subset of skill arguments.
+- D099 `B` skill import from local/Git with provenance and hash pinning.
+- D100 `B` activation fails closed on missing or incompatible skill bindings.
 
 ## 17. Deferred/Future Upgrades Already Agreed
 
@@ -315,6 +327,7 @@ runtime/
 
 - Treat this document as normative for v1 unless a new decision supersedes an item.
 - Prefer server-enforced safety to prompt-level safety.
+- Treat `SKILL.md` Markdown instructions as guidance; enforce safety from contract fields + policy.
 - Any connector or skill implementation must explicitly declare:
   - input schema/constraints,
   - permission scope,

--- a/docs/coding-agents/examples/agents/vp_of_consulting_expanses.yaml
+++ b/docs/coding-agents/examples/agents/vp_of_consulting_expanses.yaml
@@ -1,0 +1,60 @@
+schema_version: v1alpha1
+kind: agent
+
+id: vp_documenting_consulting_expenses
+name: VP of Documenting Consulting Expenses
+timezone: Asia/Tel_Aviv
+
+trigger:
+  type: schedule
+  every_minutes: 600
+
+goal: |
+  Keep my consulting expenses sheet updated from Gmail, upload attached
+  invoices and receipts to the designated Drive folder, and post a run summary
+  to Telegram. The row in the expenses sheet should adhere to the existing
+  schema of the sheet, and it should include a link to the uploaded invoice
+  and/or receipt, if one was found and uploaded.
+
+  Use the source label "Consulting Expenses" to identify emails I've designated
+  for processing. Only search for emails for the last 90 days. Mark processed
+  emails with the label "vp_expenses_processed". Only consider inbox mail.
+  Exclude already-processed mail. For each successfully processed email, apply
+  the processed label.
+
+skill_bindings:
+  - as: find_candidate_emails
+    use: gmail.inbox_label_delta_scan
+    fixed:
+      label_name: "Consulting Expenses"
+      exclude_label_names: ["vp_expenses_processed"]
+      mailbox: inbox_only
+      lookback_days: 90
+
+  - as: read_expenses_sheet
+    use: gsheet.read_tab
+    fixed:
+      spreadsheet_id: "1abcDEFghiJKLmnopQRS"
+      tab: "Expenses"
+
+  - as: upload_attachment
+    use: gdrive.upload_attachment
+    fixed:
+      folder_id: "0BxxEXPENSESfOLDER123"
+
+  - as: append_expense_row
+    use: gsheet.append_row
+    fixed:
+      spreadsheet_id: "1abcDEFghiJKLmnopQRS"
+      tab: "Expenses"
+
+  - as: mark_processed
+    use: gmail.apply_label
+    fixed:
+      label_name: "vp_expenses_processed"
+      require_existing_labels: ["Consulting Expenses"]
+
+  - as: post_report
+    use: telegram.post_message
+    fixed:
+      channel_id: "-1001234567890"

--- a/docs/coding-agents/examples/agents/vp_of_paychecks.yaml
+++ b/docs/coding-agents/examples/agents/vp_of_paychecks.yaml
@@ -1,0 +1,60 @@
+schema_version: v1alpha1
+kind: agent
+
+id: vp_documenting_consulting_expenses
+name: VP of Documenting Consulting Expenses
+timezone: Asia/Tel_Aviv
+
+trigger:
+  type: schedule
+  every_minutes: 600
+
+goal: |
+  Keep my consulting expenses sheet updated from Gmail, upload attached
+  invoices and receipts to the designated Drive folder, and post a run summary
+  to Telegram. The row in the expenses sheet should adhere to the existing
+  schema of the sheet, and it should include a link to the uploaded invoice
+  and/or receipt, if one was found and uploaded.
+
+  Use the source label "Consulting Expenses" to identify emails I've designated
+  for processing. Only search for emails for the last 90 days. Mark processed
+  emails with the label "vp_expenses_processed". Only consider inbox mail.
+  Exclude already-processed mail. For each successfully processed email, apply
+  the processed label.
+
+skill_bindings:
+  - as: find_candidate_emails
+    use: gmail.inbox_label_delta_scan
+    fixed:
+      label_name: "Consulting Expenses"
+      exclude_label_names: ["vp_expenses_processed"]
+      mailbox: inbox_only
+      lookback_days: 90
+
+  - as: read_expenses_sheet
+    use: gsheet.read_tab
+    fixed:
+      spreadsheet_id: "1abcDEFghiJKLmnopQRS"
+      tab: "Expenses"
+
+  - as: upload_attachment
+    use: gdrive.upload_attachment
+    fixed:
+      folder_id: "0BxxEXPENSESfOLDER123"
+
+  - as: append_expense_row
+    use: gsheet.append_row
+    fixed:
+      spreadsheet_id: "1abcDEFghiJKLmnopQRS"
+      tab: "Expenses"
+
+  - as: mark_processed
+    use: gmail.apply_label
+    fixed:
+      label_name: "vp_expenses_processed"
+      require_existing_labels: ["Consulting Expenses"]
+
+  - as: post_report
+    use: telegram.post_message
+    fixed:
+      channel_id: "-1001234567890"

--- a/docs/coding-agents/implementation-roadmap.md
+++ b/docs/coding-agents/implementation-roadmap.md
@@ -122,15 +122,19 @@ Goal:
 - Build strongly validated, versioned, and reversible configuration lifecycle.
 
 Issues:
-1. Define YAML schemas for agent, skill refs, triggers, policies.
-2. Add `schema_version` enforcement and migration CLI.
-3. Add YAML include/import loader with cycle detection.
-4. Implement draft -> validate -> activate flow.
-5. Implement rollback on invalid activation.
-6. Add prompt artifact version pinning.
-7. Add structured-output schemas and repair retry loop.
-8. Implement compatibility checks on permission broadening/breaking contract changes.
-9. Persist immutable run snapshots (config/prompt/skill/policy hashes).
+1. Define YAML schemas for agent goals/inputs/triggers/policies and `skill_bindings`.
+2. Define `SKILL.md` contract frontmatter schema and validation rules.
+3. Implement `SKILL.md` parser and registry ingestion pipeline.
+4. Implement global skill pool store (builtin + imported) with lockfile/provenance metadata.
+5. Implement import commands for local and Git `SKILL.md` skill packs.
+6. Add `schema_version` enforcement and migration CLI.
+7. Add YAML include/import loader with cycle detection.
+8. Implement draft -> validate -> activate flow.
+9. Implement rollback on invalid activation.
+10. Add prompt artifact version pinning.
+11. Add structured-output schemas and repair retry loop.
+12. Implement compatibility checks on permission broadening/breaking contract changes, including binding/skill compatibility.
+13. Persist immutable run snapshots (config/prompt/skill/policy hashes).
 
 Acceptance criteria:
 - Invalid config never reaches active state.
@@ -262,11 +266,11 @@ Goal:
 Issues:
 1. Define supported Python versions and CI matrix.
 2. Create dependency locking workflow for runtime and templates.
-3. Implement skill/template lockfile with provenance fields.
+3. Implement skill/template lockfile with provenance fields for imported `SKILL.md` assets.
 4. Implement explicit upgrade command with preflight and rollback snapshot.
 5. Implement release-channel config (stable/beta).
 6. Define versioned plugin API and capability flags.
-7. Add Git-based import path for skills/templates with hash pinning.
+7. Add Git-based import path for `SKILL.md` skill packs/templates with hash pinning.
 8. Add v1 boundary checks for single-user mode.
 9. Add future issue for macOS bundle packaging.
 
@@ -322,6 +326,9 @@ Acceptance criteria:
 18. `reliability: retry/backoff/circuit-breaker policy`
 19. `reliability: dead-letter queue and replay api`
 20. `security: egress allowlist enforcement`
+21. `config: SKILL.md importer and skill pool registry`
+22. `config: validate agent skill_bindings against skill pool contracts`
+23. `cli: import SKILL.md skill packs from local/Git with lockfile pinning`
 
 ## 6. Definition of Done (v1)
 

--- a/docs/coding-agents/skillmd-support-and-binding-model.md
+++ b/docs/coding-agents/skillmd-support-and-binding-model.md
@@ -1,0 +1,111 @@
+# SKILL.md Support and Binding Model
+
+Status: Design baseline
+Date: 2026-03-03
+Related ADR: [ADR-0013](./adrs/ADR-0013-skillmd-standard-skill-pool-and-agent-bindings.md)
+
+## 1. Scope
+
+This document defines how aivp fully supports `SKILL.md` as an import standard while keeping agent YAML focused on goals and optional safety constraints.
+
+## 2. Separation Model
+
+- Skill pool:
+  - canonical imported skills from `SKILL.md`
+  - each skill has id/version/hash/provenance
+  - shared across many agents
+- Agent config:
+  - references skills only through `skill_bindings`
+  - may optionally fix a subset of skill arguments
+  - does not redefine full skill interface
+
+## 3. Import Workflow
+
+1. User imports a local path or Git source.
+2. Runtime discovers `SKILL.md` files.
+3. `SKILL.md` frontmatter is validated against contract schema.
+4. Skill is registered in pool with id/version/hash/provenance.
+5. Lockfile is updated.
+6. Agent activation validates all bindings against pool contracts.
+
+## 4. Skill Pool Manifest Shape
+
+```yaml
+schema_version: skill_pool.v1
+imports:
+  - kind: local
+    path: ./skills/imported
+  - kind: git
+    url: https://github.com/example/skill-pack
+    ref: v1.4.2
+    subpath: skills
+registry:
+  - id: gmail.inbox_label_delta_scan
+    version: 1.2.0
+    source: local
+    status: active
+```
+
+## 5. SKILL.md Contract Shape
+
+`SKILL.md` must include machine-readable frontmatter and may include additional human-readable instructions in Markdown body.
+
+```md
+---
+schema_version: skill.v1
+id: gmail.inbox_label_delta_scan
+version: 1.2.0
+summary: Scan inbox emails by source label and exclude processed label.
+inputs:
+  type: object
+  required: [label_name, exclude_label_names]
+  properties:
+    label_name: { type: string }
+    exclude_label_names:
+      type: array
+      items: { type: string }
+    mailbox:
+      type: string
+      enum: [inbox_only]
+      default: inbox_only
+    lookback_days:
+      type: integer
+      minimum: 1
+      maximum: 3650
+outputs:
+  type: object
+  properties:
+    emails:
+      type: array
+permissions:
+  gmail:
+    mailbox: inbox_only
+risk:
+  level: medium
+---
+
+# Usage Notes
+This section is guidance for planning/reasoning, not the only enforcement source.
+```
+
+## 6. Agent Binding Shape
+
+```yaml
+skill_bindings:
+  - as: find_candidate_emails
+    use: gmail.inbox_label_delta_scan
+    fixed:
+      label_name: "Consulting Expenses"
+      exclude_label_names: ["vp_expenses_processed"]
+      mailbox: inbox_only
+      lookback_days: 90
+```
+
+`fixed` is optional and may include any subset of input fields.
+
+## 7. Runtime Rules
+
+- The executor validates final arguments against imported skill contract schema.
+- Policy/authorization checks run before each skill call.
+- Activation fails if `use` points to missing skill id or incompatible version/contract.
+- Run snapshots include bound skill id/version/hash.


### PR DESCRIPTION
## Summary
- add ADR-0013 to make `SKILL.md` a first-class skill import standard
- separate global skill pool contracts from per-agent `skill_bindings`
- update system design + roadmap with SKILL.md parser/registry/import and compatibility checks
- add `skillmd-support-and-binding-model.md` with concrete contract, pool manifest, and binding examples
- include updated example agent YAMLs and `.gitignore` updates from local working changes

## Design outcomes
- imported skills are canonical contracts in pool (id/version/hash/provenance)
- agents bind skills via aliases and optional `fixed` argument constraints
- activation fails closed on missing/incompatible bindings
- runtime keeps enforcement server-side (policy + executor + contract validation)
